### PR TITLE
Reverse the order of loaders

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -188,7 +188,6 @@ module.exports = {
           {
             test: /\.module\.css$/,
             use: [
-              require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),
                 options: {
@@ -218,6 +217,7 @@ module.exports = {
                   ],
                 },
               },
+              require.resolve('style-loader')
             ],
           },
           // SCSS/SASS Modules version of the above loader. Files should be suffixed as .module.s[ac]ss
@@ -226,7 +226,6 @@ module.exports = {
           {
             test: /\.module\.s[ca]ss$/,
             use: [
-              require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),
                 options: {
@@ -258,7 +257,8 @@ module.exports = {
                 },
               },
               require.resolve('resolve-url-loader'),
-              require.resolve('sass-loader') 
+              require.resolve('sass-loader'),
+              require.resolve('style-loader')
             ],
           },
           // "postcss" loader applies autoprefixer to our CSS.


### PR DESCRIPTION
Reversing the order of stylesheets so that `style-loader` appears first after `css-loader`